### PR TITLE
Add vacture english text

### DIFF
--- a/src/locales/en-GB/pages.yaml
+++ b/src/locales/en-GB/pages.yaml
@@ -308,3 +308,61 @@ tour:
     With the description: “Adopt a Krashnese: `[name/group/Teddy]`”
 
     #### Adopt the Tourcie Teddy directly
+
+vacature:
+  title: Orchestra conductor wanted for Krashna Musika
+
+  text: |
+    ## About Krashna Musika
+
+    The Delft Students Music Association (D.S.M.G.) Krashna Musika is the students classical music association of Delft, The Netherlands. The association consists of a symphony orchestra of around 90 members, a choir of around 50 members and a chamber music department of around 60 members.
+    The orchestra is one of the leading Dutch student orchestras which has been performing large symphonic works. Examples of recent projects are Rachmaninoff’s Symphony No. 2, Concerto for Orchestra by Bartok and The Planets by Holst. Besides that there are also projects with soloists on a regular basis. The orchestra aims to a semi-professional level of music. Each year there are at least two programs rehearsed, mostly in cooperation with the choir, at which the orchestra plays a large symphonic work led by the orchestra-conductor and a choir work in a smaller orchestra setting led by the choir conductor (Ruben de Grauw).
+    Krashna’s concerts mostly take place in churches in the Delft/Den Haag/Rotterdam region, but also tend to take place in the auditorium of the TU Delft and Muziekgebouw aan het IJ in Amsterdam. Next to that the orchestra and choir go on tour each two years, where they play/sing at special locations. This summer for example, the orchestra and choir went on tour to Bratislava, Brno and Vienna, whereas two years back they went sailing on tour through the waddeneilanden (group of small Dutch islands). For the last 37 years the orchestra of Krashna was directed by Daan Admiraal. With his passing last July, Krashna is looking for a new conductor for the orchestra.
+
+    ## Job description
+
+    Krashna Musika is looking for a conductor of the orchestra who conducts the orchestra from start to end each rehearsal. We rehearse every week on Monday evenings (from 19.30 till 22.30) and organise at least two concert series each year. Each project also comes with a rehearsal weekend. The conductor needs to be both musically and didactically versed. Since we work with amateurmusicians, it is important the conductor plays an active role in practicing the music with the orchestra, both technically and musically. We aim for a high musical level, but it also important the conductor is aware of the student character of the orchestra. Besides that a close cooperation with the choir conductor Ruben de Grauw is of utmost importance.
+
+    The conductor is also a part of both the audition committee and the program committee. This means he/she is present at auditions for the orchestra and is actively involved in the choice of program, together with the program committee.
+
+    This function is available starting at March 11th, when we start our new project for the concert serie in June. The program for this project has already been established. Appointment and payments are performed by the TU Delft.
+
+    ## Qualifications
+
+    - Has at least a Bachelor's degree in orchestra direction, or a provable similar level;
+    - Experience with conducting (amateur)symphonic orchestras at a high level, both during rehearsals and concerts;
+    - Broad knowledge of symphonic works, with an emphasis on (late)romantic and twentieth-century works;
+    - Proven abilities in rehearsal and project planning;
+    - Good commandment of the Dutch and/or English language;
+    - Experience in working with soloists;
+    - Experience in working with the target group (students and young adults) is an advantage.
+
+    ## We offer
+
+    - A permanent appointment at a good and enthusiastic student symphonic orchestra;
+    - Concerts both at home and abroad;
+    - The possibility to conduct large works from the symphonic repertoire.
+
+    ## Application process
+    #### Documents to be handed in
+
+    - A motivation letter\
+      *In pdf format*
+    - Curriculum Vitae\
+      *In pdf format*
+    - If possible, recent video material of conducted rehearsals and concerts\
+      *Link to online video or mp4 format*
+    - References\
+      *In pdf format, with contact details*
+
+    #### Steps in the application process
+    | | |
+    |---|---|
+    | November 25th | Application deadline |
+    | December 3rd | Candidates invited for job interview |
+    | December 13th-16th | Job interviews with selected candidates |
+    | January 12th or 19th | Try-out rehearsals with small selection |
+    | March 11th | First rehearsal of the new project |
+
+    ## Contact
+    Applications and further questions can be sent to [sollicitaties@krashna.nl](mailto:sollicitaties@krashna.nl). For more information about the association, please refer to our website [https://www.krashna.nl](https://www.krashna.nl).

--- a/src/locales/nl-NL/pages.yaml
+++ b/src/locales/nl-NL/pages.yaml
@@ -322,3 +322,61 @@ tour:
     Met de omschrijving: “Adopteer een Krashnees: `[naam/groep/Teddy]`”
 
     #### Adopteer direct de Tourcie Teddy
+
+vacature:
+  title: Orchestra conductor wanted for Krashna Musika
+
+  text: |
+    ## Over Krashna Musika
+    Het Delfts Studenten Muziekgezelschap (D.S.M.G.) Krashna Musika is het studenten klassieke muziek gezelschap van Delft. De vereniging bestaat uit een symfonie orkest van circa 90 leden, een koor van ca. 50 leden en een kamermuziekafdeling van ca. 60 leden.
+
+    Het orkest is één van de vooraanstaande studentenorkesten die al jaren grote symfonische werken neerzet. Zo zijn recent stukken als de Tweede Symfonie van Rachmaninov, het Concert voor Orkest van Bartok en de Planets van Holst gespeeld. Ook worden er geregeld werken met een solist uitgevoerd. Het orkest streeft naar een semi-professioneel muzikaal niveau. Per jaar worden er minstens twee concertprogramma’s ingestudeerd, meestal in samenwerking met het koor waar het orkest een groot symfonisch hoofdwerk speelt onder leiding van de orkestdirigent(e) en een koorwerk in kleinere bezetting onder leiding van de koordirigent (Ruben de Grauw).
+
+    Krashna geeft meestal concerten in kerken in de regio Delft/Den Haag/Rotterdam maar speelt ook regelmatig in zalen als de Aula van de TU Delft en het Muziekgebouw aan het IJ. Daarnaast gaan het orkest en koor ongeveer elke twee jaar op tournee en spelen/zingen daar op bijzondere locaties. Zo zijn wij deze zomer naar Bratislava, Brno en Wenen geweest en hebben we twee jaar geleden een tour op zeilboten langs de waddeneilanden gedaan. De laatste 37 jaar heeft het orkest van Krashna met veel plezier onder leiding gestaan van Daan Admiraal. Na zijn overlijden in juli zoekt Krashna dus nu een nieuwe dirigent(e) voor het orkest.
+
+    ## Functie-omschrijving
+    Krashna Musika is op zoek naar een dirigent(e) die het orkest van begin tot het eind bij een repetitieproces dirigeert. We repeteren elke week op maandagavond (van 19.30 tot 22.30 uur) en hebben minstens twee concertseries per jaar. Ook wordt er per project een repetitieweekend georganiseerd. De dirigent(e) moet zowel muzikaal als didactisch onderlegd zijn. Omdat we met allemaal amateurmuzikanten spelen is het belangrijk dat de dirigent(e) een actieve rol speelt in het proces van het instuderen van de muziek, dus ook technisch en niet alleen muzikaal. Wij streven naar een hoog muzikaal niveau maar daarnaast is het ook belangrijk dat de dirigent(e) bewust is van het studentenkarakter van het orkest. Daarnaast is een hechte samenwerking met de koordirigent Ruben de Grauw een vereiste.
+
+    Ook is de dirigent(e) deel van zowel de auditiecommissie als de programmacommissie. Dit betekent dat hij/zij bij de audities voor het orkest aanwezig is en hij/zij betrokken is bij de keuze voor nieuwe programma’s in samenwerking met de programmacommissie.
+
+    De functie is beschikbaar vanaf 11 maart wanneer we ons nieuwe project voor concerten in juni starten. De programmering voor dit project staat al vast. Aanstelling en honorering gebeuren via de TU Delft.
+
+    ## Kwalificaties
+
+    - Bezit van ten minste een Bachelordiploma orkestdirectie, of een aantoonbaar vergelijkbaar niveau;
+    - Ervaring met het dirigeren van (amateur)symfonieorkesten op hoog niveau, op repetities en concerten;
+    - Brede kennis van symfonisch repertoire, met name (laat)romantische en twintigste-eeuwse muziek;
+    - Bewezen vaardigheden in repetitie- en projectplanning;
+    - Goede beheersing van de Nederlandse en/of Engelse taal;
+    - Ervaring in het samenwerken met solisten;
+    - Ervaring in het werken met de doelgroep (studenten en jongeren) is een pré.
+
+    ## Wij bieden
+
+    - Een vaste plek als dirigent(e) bij een goed en enthousiast studentensymfonieorkest;
+    - Concerten in binnen en buitenland;
+    - De mogelijkheid om grote stukken uit het symfonisch repertoire uit te voeren.
+
+    ## Sollicitatieproces
+    #### In te zenden documenten
+
+    - Een motivatiebrief\
+      *In pdf formaat*
+    - Curriculum Vitae\
+      *In pdf formaat*
+    - Als mogelijk recent filmmateriaal van geleide repetities en concerten\
+      *Link naar online video of mp4 formaat*
+    - Referenties\
+      *In pdf formaat, met contactgegevens*
+
+    #### Verloop van het sollicitatieproces
+    | | |
+    |---|---|
+    | 25 november | Deadline vacature |
+    | 3 december | Kandidaten uitgenodigd op gesprek |
+    | 13-16 december | Gesprekken met geselecteerde kandidaten |
+    | 12 of 19 januari | Proefdirecties met kleine selectie|
+    | 11 maart | Eerste repetitie nieuwe project |
+
+    ## Contact
+    Voor solliciteren en verdere vragen over de sollicitatieprocedure kunt u mailen naar [sollicitaties@krashna.nl](mailto:sollicitaties@krashna.nl). Meer informatie over de vereniging is te vinden op onze website [https://www.krashna.nl](https://www.krashna.nl).

--- a/src/pages/vacature.js
+++ b/src/pages/vacature.js
@@ -1,63 +1,11 @@
 import React from 'react'
 import { translate } from 'react-i18next'
 import Markdown from 'react-remarkable'
-import CenteredImage from '../components/CenteredImage'
 import PageTemplate from '../templates/pageTemplate'
 
 const Vacature = ({ t }) => (
-  <PageTemplate title="Orkestdirigent(e) gezocht voor Krashna Musika">
-    <Markdown>{`
-## Over Krashna Musika
-Het Delfts Studenten Muziekgezelschap (D.S.M.G.) Krashna Musika is het studenten klassieke muziek gezelschap van Delft. De vereniging bestaat uit een symfonie orkest van circa 90 leden, een koor van ca. 50 leden en een kamermuziekafdeling van ca. 60 leden.
-
-Het orkest is één van de vooraanstaande studentenorkesten die al jaren grote symfonische werken neerzet. Zo zijn recent stukken als de Tweede Symfonie van Rachmaninov, het Concert voor Orkest van Bartok en de Planets van Holst gespeeld. Ook worden er geregeld werken met een solist uitgevoerd. Het orkest streeft naar een semi-professioneel muzikaal niveau. Per jaar worden er minstens twee concertprogramma’s ingestudeerd, meestal in samenwerking met het koor waar het orkest een groot symfonisch hoofdwerk speelt onder leiding van de orkestdirigent(e) en een koorwerk in kleinere bezetting onder leiding van de koordirigent (Ruben de Grauw).
-
-Krashna geeft meestal concerten in kerken in de regio Delft/Den Haag/Rotterdam maar speelt ook regelmatig in zalen als de Aula van de TU Delft en het Muziekgebouw aan het IJ. Daarnaast gaan het orkest en koor ongeveer elke twee jaar op tournee en spelen/zingen daar op bijzondere locaties. Zo zijn wij deze zomer naar Bratislava, Brno en Wenen geweest en hebben we twee jaar geleden een tour op zeilboten langs de waddeneilanden gedaan. De laatste 37 jaar heeft het orkest van Krashna met veel plezier onder leiding gestaan van Daan Admiraal. Na zijn overlijden in juli zoekt Krashna dus nu een nieuwe dirigent(e) voor het orkest.
-
-## Functie-omschrijving
-Krashna Musika is op zoek naar een dirigent(e) die het orkest van begin tot het eind bij een repetitieproces dirigeert. We repeteren elke week op maandagavond (van 19.30 tot 22.30 uur) en hebben minstens twee concertseries per jaar. Ook wordt er per project een repetitieweekend georganiseerd. De dirigent(e) moet zowel muzikaal als didactisch onderlegd zijn. Omdat we met allemaal amateurmuzikanten spelen is het belangrijk dat de dirigent(e) een actieve rol speelt in het proces van het instuderen van de muziek, dus ook technisch en niet alleen muzikaal. Wij streven naar een hoog muzikaal niveau maar daarnaast is het ook belangrijk dat de dirigent(e) bewust is van het studentenkarakter van het orkest. Daarnaast is een hechte samenwerking met de koordirigent Ruben de Grauw een vereiste.
-
-Ook is de dirigent(e) deel van zowel de auditiecommissie als de programmacommissie. Dit betekent dat hij/zij bij de audities voor het orkest aanwezig is en hij/zij betrokken is bij de keuze voor nieuwe programma’s in samenwerking met de programmacommissie.
-
-De functie is beschikbaar vanaf 11 maart wanneer we ons nieuwe project voor concerten in juni starten. De programmering voor dit project staat al vast. Aanstelling en honorering gebeuren via de TU Delft.
-
-## Kwalificaties
-- Bezit van ten minste een Bachelordiploma orkestdirectie, of een aantoonbaar vergelijkbaar niveau;
-- Ervaring met het dirigeren van (amateur)symfonieorkesten op hoog niveau, op repetities en concerten;
-- Brede kennis van symfonisch repertoire, met name (laat)romantische en twintigste-eeuwse muziek;
-- Bewezen vaardigheden in repetitie- en projectplanning;
-- Goede beheersing van de Nederlandse en/of Engelse taal;
-- Ervaring in het samenwerken met solisten;
-- Ervaring in het werken met de doelgroep (studenten en jongeren) is een pré.
-
-## Wij bieden
-- Een vaste plek als dirigent(e) bij een goed en enthousiast studentensymfonieorkest;
-- Concerten in binnen en buitenland;
-- De mogelijkheid om grote stukken uit het symfonisch repertoire uit te voeren.
-
-## Sollicitatieproces
-### In te zenden documenten
-- Een motivatiebrief\\
-*In pdf formaat*
-- Curriculum Vitae\\
-*In pdf formaat*
-- Als mogelijk recent filmmateriaal van geleide repetities en concerten\\
-*Link naar online video of mp4 formaat*
-- Referenties\\
-*In pdf formaat, met contactgegevens*
-
-### Verloop van het sollicitatieproces
-| | |
-|---|---|
-| 25 november | Deadline vacature |
-| 3 december | Kandidaten uitgenodigd op gesprek |
-| 13-16 december | Gesprekken met geselecteerde kandidaten |
-| 12 of 19 januari | Proefdirecties met kleine selectie|
-| 11 maart | Eerste repetitie nieuwe project |
-
-## Contact
-Voor solliciteren en verdere vragen over de sollicitatieprocedure kunt u mailen naar [sollicitaties@krashna.nl](mailto:sollicitaties@krashna.nl). Meer informatie over de vereniging is te vinden op onze website [https://www.krashna.nl](https://www.krashna.nl).
-      `}</Markdown>
+  <PageTemplate title={t('vacature.title')}>
+    <Markdown>{t('vacature.text')}</Markdown>
   </PageTemplate>
 )
 


### PR DESCRIPTION
Adds the Enlgish version of the job opening.

The Dutch text was extracted from `vacature.js` and put in `pages.yaml`. The new English text was added to `pages.yaml` as well (but then in the English locale). `vacature.js` was simplified to a page displaying the markdown in the `.yaml` files.