### PR TITLE
Move contact link in navbar to its own group

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -82,6 +82,7 @@ class Header extends React.Component {
               <Dropdown id="impressions" t={t} />
               <Dropdown id="business" t={t} />
               <NavLink id="join" name={t('header.join')} />
+              <NavLink id="contact" name={t('header.contact')} />
               <LanguageSwitcher />
             </div>
           </div>

--- a/src/locales/en-GB/general.yaml
+++ b/src/locales/en-GB/general.yaml
@@ -14,7 +14,6 @@ header:
     about: About Us
     committees: Committees
     recommendation: Committee of Recommendation
-    contact: Contact
   impressions:
     name: Impressions
     photos: Photos
@@ -27,7 +26,7 @@ header:
     donate: Donate
     partners: Partners
   join: Join us
-  tour: Tour 2018
+  contact: Contact us
 
 footer:
   partners: Our partners

--- a/src/locales/nl-NL/general.yaml
+++ b/src/locales/nl-NL/general.yaml
@@ -14,7 +14,6 @@ header:
     about: Over ons
     committees: Commissies
     recommendation: Comité van Aanbeveling
-    contact: Contact
   impressions:
     name: Impressies
     photos: Foto's
@@ -27,7 +26,7 @@ header:
     donate: Donateurschap
     partners: Partners
   join: Lid worden
-  tour: Tournee 2018
+  contact: Contact
 
 footer:
   partners: Onze partners


### PR DESCRIPTION
Previously, the contact link was hidden under "Association". From feedback from members it has become apparent that this is rather confusing and leads to people searching the entire menu for that contact link. To make it easier to access that (rather crucial) link, I'm putting it back to the top level of the menu.