### PR TITLE
Add coffee break redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -68,8 +68,9 @@
 # KrashKO internal ticket incasso
 /krashko-tickets https://forms.gle/MBJXUFaaK2gFNa1w6 301!
 
-# Triage form Krashna rehearsals
-/triage https://forms.gle/BPmAn2N6FjgJvGTG8 301!
+# Coronavirus redirects
 
-# Digital concert page
+/triage https://forms.gle/BPmAn2N6FjgJvGTG8 301!
 /concert /concert-2021-01-16 301!
+/coffee https://tudelft.zoom.us/j/99606267521 301!
+/koffie /coffee 301!


### PR DESCRIPTION
Should I redirect /koffie to /coffee or the zoomlink directly?

I don't think I mind that this way the zoom link becomes 'public' - should I be more concerned about this?