### PR TITLE
Te vinden op tdv weggehaald

### DIFF
--- a/src/locales/en/pages.yaml
+++ b/src/locales/en/pages.yaml
@@ -154,7 +154,7 @@ contact:
 
     ### Location
 
-    The board can currently be found at [Theater de Veste](https://www.theaterdeveste.nl/), Delft. If you want to pay us a visit, please call us so we can open the outside door for you. During rehearsals, we can still be found at [X](https://www.tudelft.nl/en/x/) of Delft University of Technology (Mekelweg 10, 2628 CD Delft).
+  During rehearsals, we can be found at [X](https://www.tudelft.nl/en/x/) of Delft University of Technology (Mekelweg 10, 2628 CD Delft).
 
     ### Board
 

--- a/src/locales/nl/pages.yaml
+++ b/src/locales/nl/pages.yaml
@@ -290,7 +290,7 @@ contact:
 
     ### Locatie
 
-    Het bestuur bevindt zich momenteel in [Theater de Veste](https://www.theaterdeveste.nl/), Delft. Als u langs wil komen, stuur dan even een belletje, dan doen wij de buitendeur open. Tijdens repetities zijn wij nog altijd te vinden op [X](https://www.tudelft.nl/en/x/) van de TU Delft (Mekelweg 10, 2628 CD Delft).
+    Tijdens repetities zijn wij te vinden op [X](https://www.tudelft.nl/en/x/) van de TU Delft (Mekelweg 10, 2628 CD Delft).
 
     ### Bestuur
 


### PR DESCRIPTION
Weggehaald dat we te vinden zijn op tdv overdag, want dat klopt lang niet altijd.